### PR TITLE
モノクロ対応

### DIFF
--- a/preprocess/classification/imagetype_classification.ipynb
+++ b/preprocess/classification/imagetype_classification.ipynb
@@ -26,7 +26,7 @@
    },
    "outputs": [],
    "source": [
-    "img = cv2.imread(\"sample.png\")\n",
+    "img = cv2.imread(\"sample7.png\")\n",
     "#opencvにおいては画像をimreadするとnumpy.ndarray形式で読み込まれる（行（高さ） x 列（幅） x 色（BGR）の三次元）\n",
     "#このとき、RGB順でなくBGR順になることに注意"
    ]
@@ -50,11 +50,12 @@
    },
    "outputs": [],
    "source": [
-    "hist_r, bins = np.histogram(r.ravel(),256,[0,256])\n",
-    "hist_g, bins = np.histogram(g.ravel(),256,[0,256])\n",
-    "hist_b, bins = np.histogram(b.ravel(),256,[0,256])\n",
-    "#RGBそれぞれについて、ヒストグラム（0-255のピクセルがそれぞれいくつあるか）を作成\n",
-    "#これもnumpy.ndarrayである"
+    "#カラーかモノクロかをまず判別する\n",
+    "def colorormono(b, g, r):\n",
+    "    if np.allclose(b, g) and np.allclose(g,r):\n",
+    "        return \"mono\"\n",
+    "    else:\n",
+    "        return \"color\""
    ]
   },
   {
@@ -65,11 +66,8 @@
    },
    "outputs": [],
    "source": [
-    "#RGBそれぞれについてヒストグラムのピークを取得\n",
-    "#r_maxなどはnumpy.int64型であることに注意\n",
-    "r_max = np.argmax(hist_r)\n",
-    "b_max = np.argmax(hist_b)\n",
-    "g_max = np.argmax(hist_g)"
+    "corm_result = colorormono(b, g, r)\n",
+    "#print(corm_result)"
    ]
   },
   {
@@ -80,22 +78,74 @@
    },
    "outputs": [],
    "source": [
-    "#jupyter内で元画像を表示するためのやつ\n",
-    "from IPython.display import Image, display_png\n",
-    "display_png(Image(\"sample.png\"))\n",
+    "def mono_classification(r):\n",
+    "    average = r.mean(0).mean(0)\n",
+    "    #R=G=Bなので1つについてのみ画素の平均を計算\n",
+    "    \n",
+    "    #jupyter内で元画像を表示するためのやつ\n",
+    "    from IPython.display import Image, display_png\n",
+    "    display_png(Image(\"sample7.png\"))\n",
+    "    \n",
+    "    #全体に明るければ背景は白、暗ければ背景は黒\n",
+    "    if average > 126:\n",
+    "        print(\"This image is type white-back.\")\n",
+    "    else:\n",
+    "        print(\"This image is type black-back.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def color_classification(r, g, b):\n",
+    "    hist_r, bins = np.histogram(r.ravel(),256,[0,256])\n",
+    "    hist_g, bins = np.histogram(g.ravel(),256,[0,256])\n",
+    "    hist_b, bins = np.histogram(b.ravel(),256,[0,256])\n",
+    "    #RGBそれぞれについて、ヒストグラム（0-255のピクセルがそれぞれいくつあるか）を作成\n",
+    "    #これもnumpy.ndarrayである\n",
     "\n",
-    "if abs(r_max - b_max) < 10 and abs(b_max - g_max) < 10 and abs(g_max - r_max) < 10:\n",
-    "    print(\"This picture is type white-purple.\")\n",
-    "#3つのピークがほぼ等しい（閾値：10）（＝ほぼ白）なら白背景の紫パターン\n",
-    "elif b_max - r_max > 7 and r_max - g_max > 7:\n",
-    "    print(\"This picture is type purple-purple.\")\n",
-    "#濃い方からピークがきれいに山3つ、Blue>Red>Greenになるようならば紫背景の紫パターン\n",
-    "elif r_max - b_max > 0 and b_max - g_max > 30:\n",
-    "    print(\"This picture is type HE.\")\n",
-    "#BlueよりRedが濃く、Greenは非常に薄くて山がかなり下なほうなのがHE染色のパターン（肉眼だと赤っぽい）\n",
+    "    #RGBそれぞれについてヒストグラムのピークを取得\n",
+    "    #r_maxなどはnumpy.int64型であることに注意\n",
+    "    r_max = np.argmax(hist_r)\n",
+    "    b_max = np.argmax(hist_b)\n",
+    "    g_max = np.argmax(hist_g)\n",
+    "    \n",
+    "    #jupyter内で元画像を表示するためのやつ\n",
+    "    from IPython.display import Image, display_png\n",
+    "    display_png(Image(\"sample7.png\"))\n",
+    "\n",
+    "    if abs(r_max - b_max) < 10 and abs(b_max - g_max) < 10 and abs(g_max - r_max) < 10:\n",
+    "        print(\"This picture is type white-purple.\")\n",
+    "    #3つのピークがほぼ等しい（閾値：10）（＝ほぼ白）なら白背景の紫パターン\n",
+    "    elif b_max - r_max > 7 and r_max - g_max > 7:\n",
+    "        print(\"This picture is type purple-purple.\")\n",
+    "    #濃い方からピークがきれいに山3つ、Blue>Red>Greenになるようならば紫背景の紫パターン\n",
+    "    elif r_max - b_max > 0 and b_max - g_max > 30:\n",
+    "        print(\"This picture is type HE.\")\n",
+    "    #BlueよりRedが濃く、Greenは非常に薄くて山がかなり下なほうなのがHE染色のパターン（肉眼だと赤っぽい）\n",
+    "    else:\n",
+    "        print(\"This picture is type white-purple(else).\")\n",
+    "    #白背景の紫パターンで、これで捉えきれないものがあるので（ガバガバふぃるたー）"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "if corm_result == \"mono\":\n",
+    "    mono_classification(r)\n",
+    "elif corm_result == \"color\":\n",
+    "    color_classification(r, g, b)\n",
     "else:\n",
-    "    print(\"This picture is type white-purple(else).\")\n",
-    "#白背景の紫パターンで、これで捉えきれないものがあるので（ガバガバふぃるたー）"
+    "    print(\"error!\")"
    ]
   }
  ],

--- a/preprocess/classification/imagetype_classification.ipynb
+++ b/preprocess/classification/imagetype_classification.ipynb
@@ -26,7 +26,7 @@
    },
    "outputs": [],
    "source": [
-    "img = cv2.imread(\"sample7.png\")\n",
+    "img = cv2.imread(\"sample.png\")\n",
     "#opencvにおいては画像をimreadするとnumpy.ndarray形式で読み込まれる（行（高さ） x 列（幅） x 色（BGR）の三次元）\n",
     "#このとき、RGB順でなくBGR順になることに注意"
    ]
@@ -84,7 +84,7 @@
     "    \n",
     "    #jupyter内で元画像を表示するためのやつ\n",
     "    from IPython.display import Image, display_png\n",
-    "    display_png(Image(\"sample7.png\"))\n",
+    "    display_png(Image(\"sample.png\"))\n",
     "    \n",
     "    #全体に明るければ背景は白、暗ければ背景は黒\n",
     "    if average > 126:\n",
@@ -116,7 +116,7 @@
     "    \n",
     "    #jupyter内で元画像を表示するためのやつ\n",
     "    from IPython.display import Image, display_png\n",
-    "    display_png(Image(\"sample7.png\"))\n",
+    "    display_png(Image(\"sample.png\"))\n",
     "\n",
     "    if abs(r_max - b_max) < 10 and abs(b_max - g_max) < 10 and abs(g_max - r_max) < 10:\n",
     "        print(\"This picture is type white-purple.\")\n",

--- a/preprocess/classification/imagetype_classification.py
+++ b/preprocess/classification/imagetype_classification.py
@@ -15,7 +15,7 @@ import numpy as np
 
 # In[ ]:
 
-img = cv2.imread("sample.png")
+img = cv2.imread("sample7.png")
 #opencvにおいては画像をimreadするとnumpy.ndarray形式で読み込まれる（行（高さ） x 列（幅） x 色（BGR）の三次元）
 #このとき、RGB順でなくBGR順になることに注意
 
@@ -27,38 +27,76 @@ b, g, r = img[:,:,0], img[:,:,1], img[:,:,2]
 
 # In[ ]:
 
-hist_r, bins = np.histogram(r.ravel(),256,[0,256])
-hist_g, bins = np.histogram(g.ravel(),256,[0,256])
-hist_b, bins = np.histogram(b.ravel(),256,[0,256])
-#RGBそれぞれについて、ヒストグラム（0-255のピクセルがそれぞれいくつあるか）を作成
-#これもnumpy.ndarrayである
+#カラーかモノクロかをまず判別する
+def colorormono(b, g, r):
+    if np.allclose(b, g) and np.allclose(g,r):
+        return "mono"
+    else:
+        return "color"
 
 
 # In[ ]:
 
-#RGBそれぞれについてヒストグラムのピークを取得
-#r_maxなどはnumpy.int64型であることに注意
-r_max = np.argmax(hist_r)
-b_max = np.argmax(hist_b)
-g_max = np.argmax(hist_g)
+corm_result = colorormono(b, g, r)
+#print(corm_result)
 
 
 # In[ ]:
 
-#jupyter内で元画像を表示するためのやつ
-from IPython.display import Image, display_png
-display_png(Image("sample.png"))
+def mono_classification(r):
+    average = r.mean(0).mean(0)
+    #R=G=Bなので1つについてのみ画素の平均を計算
+    
+    #jupyter内で元画像を表示するためのやつ
+    from IPython.display import Image, display_png
+    display_png(Image("sample7.png"))
+    
+    #全体に明るければ背景は白、暗ければ背景は黒
+    if average > 126:
+        print("This image is type white-back.")
+    else:
+        print("This image is type black-back.")
 
-if abs(r_max - b_max) < 10 and abs(b_max - g_max) < 10 and abs(g_max - r_max) < 10:
-    print("This picture is type white-purple.")
-#3つのピークがほぼ等しい（閾値：10）（＝ほぼ白）なら白背景の紫パターン
-elif b_max - r_max > 7 and r_max - g_max > 7:
-    print("This picture is type purple-purple.")
-#濃い方からピークがきれいに山3つ、Blue>Red>Greenになるようならば紫背景の紫パターン
-elif r_max - b_max > 0 and b_max - g_max > 30:
-    print("This picture is type HE.")
-#BlueよりRedが濃く、Greenは非常に薄くて山がかなり下なほうなのがHE染色のパターン（肉眼だと赤っぽい）
+
+# In[ ]:
+
+def color_classification(r, g, b):
+    hist_r, bins = np.histogram(r.ravel(),256,[0,256])
+    hist_g, bins = np.histogram(g.ravel(),256,[0,256])
+    hist_b, bins = np.histogram(b.ravel(),256,[0,256])
+    #RGBそれぞれについて、ヒストグラム（0-255のピクセルがそれぞれいくつあるか）を作成
+    #これもnumpy.ndarrayである
+
+    #RGBそれぞれについてヒストグラムのピークを取得
+    #r_maxなどはnumpy.int64型であることに注意
+    r_max = np.argmax(hist_r)
+    b_max = np.argmax(hist_b)
+    g_max = np.argmax(hist_g)
+    
+    #jupyter内で元画像を表示するためのやつ
+    from IPython.display import Image, display_png
+    display_png(Image("sample7.png"))
+
+    if abs(r_max - b_max) < 10 and abs(b_max - g_max) < 10 and abs(g_max - r_max) < 10:
+        print("This picture is type white-purple.")
+    #3つのピークがほぼ等しい（閾値：10）（＝ほぼ白）なら白背景の紫パターン
+    elif b_max - r_max > 7 and r_max - g_max > 7:
+        print("This picture is type purple-purple.")
+    #濃い方からピークがきれいに山3つ、Blue>Red>Greenになるようならば紫背景の紫パターン
+    elif r_max - b_max > 0 and b_max - g_max > 30:
+        print("This picture is type HE.")
+    #BlueよりRedが濃く、Greenは非常に薄くて山がかなり下なほうなのがHE染色のパターン（肉眼だと赤っぽい）
+    else:
+        print("This picture is type white-purple(else).")
+    #白背景の紫パターンで、これで捉えきれないものがあるので（ガバガバふぃるたー）
+
+
+# In[ ]:
+
+if corm_result == "mono":
+    mono_classification(r)
+elif corm_result == "color":
+    color_classification(r, g, b)
 else:
-    print("This picture is type white-purple(else).")
-#白背景の紫パターンで、これで捉えきれないものがあるので（ガバガバふぃるたー）
+    print("error!")
 

--- a/preprocess/classification/imagetype_classification.py
+++ b/preprocess/classification/imagetype_classification.py
@@ -15,7 +15,7 @@ import numpy as np
 
 # In[ ]:
 
-img = cv2.imread("sample7.png")
+img = cv2.imread("sample.png")
 #opencvにおいては画像をimreadするとnumpy.ndarray形式で読み込まれる（行（高さ） x 列（幅） x 色（BGR）の三次元）
 #このとき、RGB順でなくBGR順になることに注意
 
@@ -49,7 +49,7 @@ def mono_classification(r):
     
     #jupyter内で元画像を表示するためのやつ
     from IPython.display import Image, display_png
-    display_png(Image("sample7.png"))
+    display_png(Image("sample.png"))
     
     #全体に明るければ背景は白、暗ければ背景は黒
     if average > 126:
@@ -75,7 +75,7 @@ def color_classification(r, g, b):
     
     #jupyter内で元画像を表示するためのやつ
     from IPython.display import Image, display_png
-    display_png(Image("sample7.png"))
+    display_png(Image("sample.png"))
 
     if abs(r_max - b_max) < 10 and abs(b_max - g_max) < 10 and abs(g_max - r_max) < 10:
         print("This picture is type white-purple.")


### PR DESCRIPTION
(train_imagesとtest_imagesにある範囲の）すべてのタイプの画像について、入力するとどのタイプかを返せるようになりました（全5種類）。
組織の少ないHE染色がwhite-purpleと判定される問題には手をつけていません。